### PR TITLE
Added/updated translations: cs_cz, de_de, hu_hu, it_it, ru_ru, uk_ua

### DIFF
--- a/common/src/main/resources/assets/crafting_on_a_stick/lang/cs_cz.json
+++ b/common/src/main/resources/assets/crafting_on_a_stick/lang/cs_cz.json
@@ -1,9 +1,9 @@
 {
-	"item.crafting_on_a_stick.template": "%s на паличці",
-	"itemGroup.crafting_on_a_stick": "Крафт на паличці",
-	"curios.identifier.crafting_on_a_stick": "Крафт на паличці",
-	"crafting_on_a_stick.key.open_curios": "Відкрити крафт на паличці",
-	"gui.crafting_on_a_stick.selection_wheel.no_tool": "У вас немає жодного інструмента",
+	"item.crafting_on_a_stick.template": "%s na tyči",
+	"itemGroup.crafting_on_a_stick": "Crafting na tyči",
+	"curios.identifier.crafting_on_a_stick": "Crafting na tyči",
+	"crafting_on_a_stick.key.open_curios": "Otevřít crafting na tyči",
+	"gui.crafting_on_a_stick.selection_wheel.no_tool": "Nemáš žádný nástroj",
 
 	"item.crafting_on_a_stick.crafting_table": "%s",
 	"item.crafting_on_a_stick.loom": "%s",

--- a/common/src/main/resources/assets/crafting_on_a_stick/lang/de_de.json
+++ b/common/src/main/resources/assets/crafting_on_a_stick/lang/de_de.json
@@ -1,9 +1,9 @@
 {
-	"item.crafting_on_a_stick.template": "%s на паличці",
-	"itemGroup.crafting_on_a_stick": "Крафт на паличці",
-	"curios.identifier.crafting_on_a_stick": "Крафт на паличці",
-	"crafting_on_a_stick.key.open_curios": "Відкрити крафт на паличці",
-	"gui.crafting_on_a_stick.selection_wheel.no_tool": "У вас немає жодного інструмента",
+	"item.crafting_on_a_stick.template": "%s am Stiel",
+	"itemGroup.crafting_on_a_stick": "Werkbank am Stiel",
+	"curios.identifier.crafting_on_a_stick": "Werkbank am Stiel",
+	"crafting_on_a_stick.key.open_curios": "Werkbank am Stiel öffnen",
+	"gui.crafting_on_a_stick.selection_wheel.no_tool": "Du hast kein Werkzeug",
 
 	"item.crafting_on_a_stick.crafting_table": "%s",
 	"item.crafting_on_a_stick.loom": "%s",

--- a/common/src/main/resources/assets/crafting_on_a_stick/lang/hu_hu.json
+++ b/common/src/main/resources/assets/crafting_on_a_stick/lang/hu_hu.json
@@ -1,9 +1,9 @@
 {
-	"item.crafting_on_a_stick.template": "%s на паличці",
-	"itemGroup.crafting_on_a_stick": "Крафт на паличці",
-	"curios.identifier.crafting_on_a_stick": "Крафт на паличці",
-	"crafting_on_a_stick.key.open_curios": "Відкрити крафт на паличці",
-	"gui.crafting_on_a_stick.selection_wheel.no_tool": "У вас немає жодного інструмента",
+	"item.crafting_on_a_stick.template": "%s boton",
+	"itemGroup.crafting_on_a_stick": "Crafting boton",
+	"curios.identifier.crafting_on_a_stick": "Crafting boton",
+	"crafting_on_a_stick.key.open_curios": "Crafting boton megnyitása",
+	"gui.crafting_on_a_stick.selection_wheel.no_tool": "Nincs egyetlen szerszámod sem",
 
 	"item.crafting_on_a_stick.crafting_table": "%s",
 	"item.crafting_on_a_stick.loom": "%s",

--- a/common/src/main/resources/assets/crafting_on_a_stick/lang/it_it.json
+++ b/common/src/main/resources/assets/crafting_on_a_stick/lang/it_it.json
@@ -1,15 +1,17 @@
 {
-  "item.crafting_on_a_stick.crafting_table": "Banco da lavoro su un bastone",
-  "item.crafting_on_a_stick.loom": "Telaio su un bastone",
-  "item.crafting_on_a_stick.grindstone": "Mola su un bastone",
-  "item.crafting_on_a_stick.cartography_table": "Banco da cartografia su un bastone",
-  "item.crafting_on_a_stick.stonecutter": "Tagliapietre su un bastone",
-  "item.crafting_on_a_stick.smithing_table": "Banco da forgiatura su un bastone",
-  "item.crafting_on_a_stick.anvil": "Incudine su un bastone",
-  "item.crafting_on_a_stick.chipped_anvil": "Incudine scheggiata su un bastone",
-  "item.crafting_on_a_stick.damaged_anvil": "Incudine danneggiata su un bastone",
+	"item.crafting_on_a_stick.template": "%s su un bastone",
+	"item.crafting_on_a_stick.crafting_table": "Banco da lavoro su un bastone",
+	"item.crafting_on_a_stick.loom": "Telaio su un bastone",
+	"item.crafting_on_a_stick.grindstone": "Mola su un bastone",
+	"item.crafting_on_a_stick.cartography_table": "Banco da cartografia su un bastone",
+	"item.crafting_on_a_stick.stonecutter": "Tagliapietre su un bastone",
+	"item.crafting_on_a_stick.smithing_table": "Banco da forgiatura su un bastone",
+	"item.crafting_on_a_stick.anvil": "Incudine su un bastone",
+	"item.crafting_on_a_stick.chipped_anvil": "Incudine scheggiata su un bastone",
+	"item.crafting_on_a_stick.damaged_anvil": "Incudine danneggiata su un bastone",
 
-  "itemGroup.crafting_on_a_stick": "Fabbricazione su un bastone",
-  "curios.identifier.crafting_on_a_stick": "Fabbricazione su un bastone",
-  "crafting_on_a_stick.key.open_curios": "Apri la fabbricazione con un bastone"
+	"itemGroup.crafting_on_a_stick": "Fabbricazione su un bastone",
+	"curios.identifier.crafting_on_a_stick": "Fabbricazione su un bastone",
+	"crafting_on_a_stick.key.open_curios": "Apri la fabbricazione su un bastone",
+	"gui.crafting_on_a_stick.selection_wheel.no_tool": "Non hai alcuno strumento"
 }

--- a/common/src/main/resources/assets/crafting_on_a_stick/lang/ru_ru.json
+++ b/common/src/main/resources/assets/crafting_on_a_stick/lang/ru_ru.json
@@ -1,3 +1,17 @@
 {
-	"item.crafting_on_a_stick.template": "%s на Палке"
+	"item.crafting_on_a_stick.template": "%s на палке",
+	"itemGroup.crafting_on_a_stick": "Крафт на палке",
+	"curios.identifier.crafting_on_a_stick": "Крафт на палке",
+	"crafting_on_a_stick.key.open_curios": "Открыть крафт на палке",
+	"gui.crafting_on_a_stick.selection_wheel.no_tool": "У вас нет ни одного инструмента",
+
+	"item.crafting_on_a_stick.crafting_table": "%s",
+	"item.crafting_on_a_stick.loom": "%s",
+	"item.crafting_on_a_stick.grindstone": "%s",
+	"item.crafting_on_a_stick.cartography_table": "%s",
+	"item.crafting_on_a_stick.stonecutter": "%s",
+	"item.crafting_on_a_stick.smithing_table": "%s",
+	"item.crafting_on_a_stick.anvil": "%s",
+	"item.crafting_on_a_stick.chipped_anvil": "%s",
+	"item.crafting_on_a_stick.damaged_anvil": "%s"
 }


### PR DESCRIPTION
Added complete translations (14 keys each) for 6 languages:

- **cs_cz** (Czech) — new, template: `%s na tyči`
- **de_de** (German) — new, template: `%s am Stiel`
- **hu_hu** (Hungarian) — new, template: `%s boton`
- **it_it** (Italian) — updated: added template key and `no_tool` message
- **ru_ru** (Russian) — updated from 1 key to full set, template: `%s на палке`
- **uk_ua** (Ukrainian) — updated from 1 key to full set, template: `%s на паличці`

Item names use the template pattern so they automatically pick up the block's translated name from the game (e.g. "Верстак на палке", "Werkbank am Stiel").